### PR TITLE
Bump minimum owasp dependency check version

### DIFF
--- a/lib/fastlane/plugin/dependency_check_ios_analyzer/helper/configuration_helper.rb
+++ b/lib/fastlane/plugin/dependency_check_ios_analyzer/helper/configuration_helper.rb
@@ -10,7 +10,7 @@ module Fastlane
       def self.install(params)
         repo = 'https://github.com/jeremylong/DependencyCheck'
         name = 'dependency-check'
-        version = params[:cli_version] ? params[:cli_version] : '6.2.2'
+        version = params[:cli_version] ? params[:cli_version] : '7.4.4'
         base_url = "#{repo}/releases/download/v#{version}/#{name}-#{version}-release"
         bin_path = "#{params[:output_directory]}/#{name}/bin/#{name}.sh"
         zip_path = "#{params[:output_directory]}/#{name}.zip"

--- a/lib/fastlane/plugin/dependency_check_ios_analyzer/version.rb
+++ b/lib/fastlane/plugin/dependency_check_ios_analyzer/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DependencyCheckIosAnalyzer
-    VERSION = '1.2.0'
+    VERSION = '1.3.0'
   end
 end


### PR DESCRIPTION
# Changes

## References
- https://github.com/alteral/fastlane-plugin-dependency_check_ios_analyzer/issues/XXX

## Risks
- [ ] None
- [ ] Low
- [ ] High
